### PR TITLE
chore: migrate renovate preset to tasshi-me/configs

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -1,6 +1,6 @@
 {
   "extends": [
-    "github>tasshi-me/renovate-config",
+    "github>tasshi-me/configs",
     ":semanticCommits"
   ]
 }


### PR DESCRIPTION
The shareable Renovate preset moved from `tasshi-me/renovate-config` to [`tasshi-me/configs`](https://github.com/tasshi-me/configs). This updates the `extends` reference accordingly. `renovate-config` will be archived afterwards.